### PR TITLE
Fix link to correct license on contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,5 +81,5 @@ be more awesomer!
 
 ## License
 
-By contributing your code, you agree to license your contribution under the terms of the APLv2: https://github.com/twitter/bootstrap/blob/master/LICENSE
+By contributing your code, you agree to license your contribution under the terms of the [APLv2](LICENSE)
 


### PR DESCRIPTION
The link on the contributing page links to the Twitter Bootstrap license file which is MIT, not APLv2.
