### PR TITLE
Set cursor to default

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -26,7 +26,7 @@
   line-height: @baseLineHeight;
   text-align: center;
   vertical-align: middle;
-  cursor: pointer;
+  cursor: default;
   background: @gray;
   .border-radius(@baseBorderRadius);
   .ie7-restore-left-whitespace(); // Give IE7 some love


### PR DESCRIPTION
Since back in the Eighties we had no graphical pointers, using the default mouse pointer everywhere seems reasonable to me, and is looks better than simulating block character transparent pointer (issue #21).
